### PR TITLE
Support xmlns tags

### DIFF
--- a/lib/xml-flow.js
+++ b/lib/xml-flow.js
@@ -29,9 +29,34 @@ flow = module.exports = function xmlFlow(inStream, opts) {
 
   saxStream = sax.createStream(options.strict || false, saxOptions);
 
+  var namespaces = [];
   saxStream.on('opentag', function openTag(node) {
+    if (node.attributes) {
+      var localNamespaces = {};
+      for (var a in node.attributes) {
+        if (a.indexOf('xmlns:') === 0) {
+          localNamespaces[a.slice(6)] = node.attributes[a];
+        }
+      }
+
+      namespaces.push(localNamespaces);
+    }
+
+    var nodeName = node.name;
+    var nsUri;
+    if (node.name.indexOf(':')) {
+      var prefix = node.name.slice(0, node.name.indexOf(':'));
+      var localName = node.name.slice(node.name.indexOf(':') + 1);
+
+      for (var i = 0; i < namespaces.length; i++) {
+        nsUri = nsUri || namespaces[i][prefix];
+      }
+
+      nodeName = nsUri + ' ' + localName;
+    }
+
     //Ignore nodes we don't care about.
-    if (stack.length === 0 && !emitter.listeners('tag:' + node.name).length) {
+    if (stack.length === 0 && !emitter.listeners('tag:' + nodeName).length) {
       return;
     }
 
@@ -40,6 +65,7 @@ flow = module.exports = function xmlFlow(inStream, opts) {
 
     topNode = {
       $name: node.name,
+      $ns: nsUri,
       $attrs: node.attributes
     };
 
@@ -109,6 +135,19 @@ flow = module.exports = function xmlFlow(inStream, opts) {
       , keepArrays = options.useArrays > flow.SOMETIMES
       ;
 
+    var nodeName = tagName;
+    var nsUri;
+    if (nodeName.indexOf(':')) {
+      var prefix = tagName.slice(0, tagName.indexOf(':'));
+      var localName = tagName.slice(tagName.indexOf(':') + 1);
+
+      for (var i = 0; i < namespaces.length; i++) {
+        nsUri = nsUri || namespaces[i][prefix];
+      }
+
+      nodeName = nsUri + ' ' + localName;
+    }
+
     //If we're not going to send out a node, goodbye!
     if (stack.length === 0) return;
 
@@ -127,15 +166,16 @@ flow = module.exports = function xmlFlow(inStream, opts) {
     }
 
     //emit the node if there are listeners
-    if (emitter.listeners('tag:' + tagName).length) {
+    if (emitter.listeners('tag:' + nodeName).length) {
       emitter.emit(
-        'tag:' + tagName,
+        'tag:' + nodeName,
         options.simplifyNodes ? helper.simplifyNode(topNode, false, options.useArrays > flow.SOMETIMES) : topNode
       );
     }
 
     //Pop stack, and add to parent node
     stack.pop();
+    namespaces.pop();
     if (stack.length > 0) {
       newTop = stack[stack.length - 1];
       if (options.useArrays > flow.NEVER) {

--- a/test/with-ns.xml
+++ b/test/with-ns.xml
@@ -1,0 +1,3 @@
+<root xmlns:a="my:ns">
+  <a:alien>Thing1</a:alien>
+</root>

--- a/test/xml-flow.js
+++ b/test/xml-flow.js
@@ -53,12 +53,7 @@ describe('xml-flow', function() {
     });
 
     it('should listen to tags with namespaces', function(done) {
-      var simpleStream = getFlow('./test/with-ns.xml')
-      , output = {
-        $name: 'alien',
-        $ns: 'my:ns'
-      }
-      ;
+      var simpleStream = getFlow('./test/with-ns.xml');
 
       simpleStream.on('tag:my:ns alien', function() {
         done();

--- a/test/xml-flow.js
+++ b/test/xml-flow.js
@@ -52,6 +52,19 @@ describe('xml-flow', function() {
       });
     });
 
+    it('should listen to tags with namespaces', function(done) {
+      var simpleStream = getFlow('./test/with-ns.xml')
+      , output = {
+        $name: 'alien',
+        $ns: 'my:ns'
+      }
+      ;
+
+      simpleStream.on('tag:my:ns alien', function() {
+        done();
+      });
+    });
+
     it('should make non-attributed data look really simple', function(done) {
       var simpleStream = getFlow('./test/test.xml')
         , output = {


### PR DESCRIPTION
Provide support for tags with namespaces
I created a small patch that has a stack of namespace prefixes. It also contains a test for:

```
<root xmlns:a="my:ns">
  <a:alien>Thing1</a:alien>
</root>
```

which emits `tag:my:ns alien` event. Notice the space between the namespace uri and the tag name. I chose the space because it's not a valid tag name character.
