### PR TITLE
Do not convert arrays to objects on shallowClone

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -57,6 +57,11 @@ function shallowClone(obj) {
     ;
 
   if (obj === null || typeof obj !== 'object') return obj;
+  if (obj.constructor === Array)
+    output = [];
+  else
+    output = {};
+
   for (key in obj) {
     if (obj.hasOwnProperty(key)) {
       output[key] = obj[key];

--- a/test/helper.simplifyNode.js
+++ b/test/helper.simplifyNode.js
@@ -101,6 +101,20 @@ describe('helper.simplifyNode()', function() {
     helper.simplifyNode([ 'test' ], false, true).should.deep.equal([ 'test' ]);
   });
 
+  it('should simplify arrays as arrays', function() {
+    var input, output;
+
+    input = {
+      items: [ { id: 1 }, { id: 2 } ]
+    };
+
+    output = [
+      { id: 1 }, { id: 2 }
+    ];
+
+    helper.simplifyNode(input).should.deep.equal(output);
+  });
+
   it('should not simplify when things get interesting', function() {
     var input, output;
 


### PR DESCRIPTION
As mentioned in #14 with this fix arrays stay arrays and don't get converted to objects with numeric keys.