### PR TITLE
Add onerror emitter

### DIFF
--- a/lib/xml-flow.js
+++ b/lib/xml-flow.js
@@ -151,6 +151,10 @@ flow = module.exports = function xmlFlow(inStream, opts) {
     emitter.emit('end');
   });
 
+  saxStream.on('error', function onError(error) {
+    emitter.emit('error', error);
+  });
+
   inStream.pipe(saxStream);
 
   emitter.pause = function pause() {


### PR DESCRIPTION
Addresses #12

Catches `saxStream.on('error')` so that `flow` can catch errors properly.